### PR TITLE
chore: clean up fork rebase - reset version to 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">⚒️ Forge: AI-Enhanced Terminal Development Environment</h1>
 <p align="center">A comprehensive coding agent that integrates AI capabilities with your development environment</p>
 
-<p align="center"><code>curl -fsSL https://forgecode.dev/cli | sh</code></p>
+<p align="center"><code>curl -fsSL https://raw.githubusercontent.com/Teckwin/forgecode/refs/heads/main/scripts/install.sh | sh</code></p>
 
 [![CI Status](https://img.shields.io/github/actions/workflow/status/antinomyhq/forge/ci.yml?style=for-the-badge)](https://github.com/antinomyhq/forge/actions)
 [![GitHub Release](https://img.shields.io/github/v/release/antinomyhq/forge?style=for-the-badge)](https://github.com/antinomyhq/forge/releases)
@@ -42,7 +42,7 @@
 To get started with Forge, run the command below:
 
 ```bash
-curl -fsSL https://forgecode.dev/cli | sh
+curl -fsSL https://raw.githubusercontent.com/Teckwin/forgecode/refs/heads/main/scripts/install.sh | sh
 ```
 
 On first run, Forge will guide you through setting up your AI provider credentials using the interactive login flow. Alternatively, you can configure providers beforehand:
@@ -837,7 +837,7 @@ For comprehensive documentation on all features and capabilities, please visit t
 
 ```bash
 # YOLO
-curl -fsSL https://forgecode.dev/cli | sh
+curl -fsSL https://raw.githubusercontent.com/Teckwin/forgecode/refs/heads/main/scripts/install.sh | sh
 
 # Package managers
 nix run github:antinomyhq/forge # for latest dev branch


### PR DESCRIPTION
## 描述

清理 fork 项目，重置版本号从 0.1.0 开始。

## 改动内容

- 删除所有本地 git tag，从头开始管理版本
- 验证所有安装/更新引用已正确指向 fork 项目 (Teckwin/forgecode)
- 版本号已设为 0.1.0
- 添加空 commit 以便创建 PR

## 发布准备
- [x] 版本号已更新为: 0.1.0
- [x] 所有更新引用指向 fork

## 测试
- [x] 本地测试通过