### PR TITLE
docs: improve release workflow documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,18 +5,43 @@
 This repository has GitHub **immutable releases** enforced. Published releases
 cannot have assets uploaded after publication. This is a critical constraint.
 
-### How releases work
+### How releases work — correct sequence (verified: v0.1.3, v0.1.4)
 
 ```
-ci.yml (push to main):
-  build test → draft_release → build_release (uploads binaries to DRAFT)
-
-Manual step:
-  GitHub UI → Releases → Publish the draft
-
-release.yml (release: published):
-  Kept for upstream compatibility. Will fail on asset upload due to
-  immutable releases — this is expected and matches upstream behavior.
+┌─────────────────────────────────────────────────────────────────┐
+│ ci.yml (triggers: push to main OR v* tag push)                  │
+│                                                                 │
+│   1. build (test + coverage)                                    │
+│   2. draft_release (release-drafter creates/updates DRAFT)      │
+│      ↓ needs: build                                             │
+│      ↓ condition: push to main only                             │
+│   3. build_release (9 platform binaries → upload to DRAFT)      │
+│      ↓ needs: draft_release                                     │
+│      ↓ condition: push to main only                             │
+│                                                                 │
+│   Result: Draft release with all 9 binaries attached            │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ Manual step: GitHub UI → Releases → Publish the draft           │
+│                                                                 │
+│   This transitions the draft to a published release.            │
+│   All binaries are already present — no upload needed.          │
+└─────────────────────────────────────────────────────────────────┘
+                            ↓
+┌─────────────────────────────────────────────────────────────────┐
+│ release.yml "Multi Channel Release" (trigger: release published)│
+│                                                                 │
+│   Tries to rebuild + re-upload binaries to the published release│
+│   ⚠ EXPECTED FAILURE: "Upload to Release" step fails because   │
+│   immutable releases reject asset uploads after publication.    │
+│   The first platform to finish build (e.g. x86_64-apple-darwin)│
+│   fails at upload, cancelling the remaining matrix jobs.        │
+│                                                                 │
+│   THIS IS FINE — the binaries were already uploaded during the  │
+│   draft phase by ci.yml. This workflow exists only for upstream │
+│   compatibility with antinomyhq/forgecode.                      │
+└─────────────────────────────────────────────────────────────────┘
 ```
 
 ### Rules for AI agents
@@ -30,6 +55,11 @@ release.yml (release: published):
    the draft release flow in ci.yml, NOT to modify release.yml
 5. Keep release.yml as close to upstream (antinomyhq/forgecode) as possible,
    only removing npm_release and homebrew_release jobs
+6. The "Multi Channel Release" workflow **always shows as failed** in GitHub Actions
+   after publishing a draft — this is normal and expected. Do NOT attempt to fix it.
+7. If ci.yml's `build_release` job fails, the draft will have missing binaries.
+   Fix the build issue and re-push to main — release-drafter will update the
+   existing draft, and `build_release` will upload the missing binaries.
 
 ### Key files
 
@@ -37,3 +67,16 @@ release.yml (release: published):
 - `crates/forge_ci/src/workflows/ci.rs` — generates ci.yml (has draft release flow)
 - `crates/forge_ci/src/jobs/release_build_job.rs` — shared build matrix job
 - `crates/forge_ci/src/jobs/release_draft.rs` — draft release creation job
+
+## Open Feature Issues
+
+### Issue #42: Align .forge/ directory convention with Claude Code
+- Add `tools/` and `agents/` directory support
+- Consolidate `policies.yaml` into `settings.json`
+- Extend config adapter migration coverage (currently 45%)
+
+### Issue #45: Complete auto-memory integration and conversational definitions
+- Wire `ForgeMemoryService` into agent pipeline (load + system prompt + tools)
+- Add `create-agent`, `create-rule`, `create-tool` skills
+- Hot-reload for definitions created mid-session
+- Depends on #42 (directories must exist before runtime can use them)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,10 @@ cannot have assets uploaded after publication. This is a critical constraint.
 │   Tries to rebuild + re-upload binaries to the published release│
 │   ⚠ EXPECTED FAILURE: "Upload to Release" step fails because   │
 │   immutable releases reject asset uploads after publication.    │
-│   The first platform to finish build (e.g. x86_64-apple-darwin)│
-│   fails at upload, cancelling the remaining matrix jobs.        │
+│   The fastest platform to finish its build reaches the upload   │
+│   step first and fails, triggering fail-fast cascade that       │
+│   cancels all remaining matrix jobs (e.g. v0.1.4:               │
+│   x86_64-apple-darwin failed → 8 others cancelled).             │
 │                                                                 │
 │   THIS IS FINE — the binaries were already uploaded during the  │
 │   draft phase by ci.yml. This workflow exists only for upstream │


### PR DESCRIPTION
## Summary
- Replace simplified release flow description with detailed ASCII diagram showing all 3 stages
- Add agent rules #6 (failure is expected) and #7 (recovery procedure)
- Document ci.yml dual triggers (push-to-main + v* tag)
- Add Issue #42/#45 summaries for AI agent context
- Verified against v0.1.3 and v0.1.4 successful releases

## Test plan
- [x] Review diff — confirm flow diagram matches actual ci.yml/release.yml behavior
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)